### PR TITLE
Make all event listeners passive where supported

### DIFF
--- a/src/tracker/engaged_time.js
+++ b/src/tracker/engaged_time.js
@@ -85,9 +85,17 @@ limitations under the License.
         root.focused = false;
     });
 
+    var supportsPassive = false;
+    try {
+        addEventListener("test", null, { get capture() { supportsPassive = true; } });
+    } catch(e) {}
+    var optionsOrCapture = false;
+    if (supportsPassive)
+        optionsOrCapture = {passive:true, capture:false}
+    
     var _buildListener = function(event_name, callback) {
         if (window.addEventListener) {
-            window.addEventListener(event_name, callback, false);
+            window.addEventListener(event_name, callback, optionsOrCapture);
         } else {
             document.attachEvent("on" + event_name, callback);
         }

--- a/src/tracker/engaged_time.js
+++ b/src/tracker/engaged_time.js
@@ -87,7 +87,9 @@ limitations under the License.
 
     var supportsPassive = false;
     try {
-        addEventListener("test", null, { get passive() { supportsPassive = true; } });
+        addEventListener("test", null, Object.defineProperty({}, 'passive', {get: function () {
+            supportsPassive = true;
+        }}));
     } catch(e) {}
     var optionsOrCapture = false;
     if (supportsPassive)

--- a/src/tracker/engaged_time.js
+++ b/src/tracker/engaged_time.js
@@ -87,7 +87,7 @@ limitations under the License.
 
     var supportsPassive = false;
     try {
-        addEventListener("test", null, { get capture() { supportsPassive = true; } });
+        addEventListener("test", null, { get passive() { supportsPassive = true; } });
     } catch(e) {}
     var optionsOrCapture = false;
     if (supportsPassive)


### PR DESCRIPTION
See [the passive event listener explainer](https://github.com/WICG/EventListenerOptions/blob/gh-pages/explainer.md).  In practice we believe changing just this one script will have a measurable scroll performance improvement on the web.  Fixes #3.
